### PR TITLE
enhanment: try to get property description from common comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,8 @@ dist
 # TernJS port file
 .tern-port
 
+# IDE config
+.idea
+
+# dist files
 lib/


### PR DESCRIPTION
If `@zh` or `@en` is not provided, try to get the property description information from ordinary comments.