### PR TITLE
 escape parsing types with JSDoc title and use ast to add links to display type text

### DIFF
--- a/__test__/__snapshots__/index.test.ts.snap
+++ b/__test__/__snapshots__/index.test.ts.snap
@@ -600,6 +600,21 @@ Object {
         "type": "[BlinkProps](blink#Blink)",
       },
       Object {
+        "isOptional": false,
+        "name": "unionBlink",
+        "tags": Array [
+          Object {
+            "name": "zh",
+            "value": "属性 baseB",
+          },
+          Object {
+            "name": "en",
+            "value": "baseBlink",
+          },
+        ],
+        "type": "[UnionBlinkProps](#UnionBlinkProps)",
+      },
+      Object {
         "isOptional": true,
         "name": "action",
         "tags": Array [
@@ -861,6 +876,17 @@ Object {
       Object {
         "name": "title",
         "value": "TreeSelectDataType",
+      },
+    ],
+  },
+  "UnionBlinkProps": Object {
+    "data": "type UnionBlinkProps = ClinkProps & BlinkProps;
+",
+    "isNestedType": true,
+    "tags": Array [
+      Object {
+        "name": "title",
+        "value": "UnionBlinkProps",
       },
     ],
   },
@@ -1305,6 +1331,7 @@ Object {
 |treeSelectDataType|树选择数据属性|[TreeSelectDataType](#TreeSelectDataType) |\`-\`|
 |onClick|点击回调|(num: number) => void  **(必填)**|\`-\`|
 |b|属性 B|[BlinkProps](blink#Blink)  **(必填)**|\`-\`|
+|unionBlink|属性 baseB|[UnionBlinkProps](#UnionBlinkProps)  **(必填)**|\`-\`|
 |action|操作项|ReactNode |\`-\`|
 |owner|负责人|Partial&lt;[Owner](#Owner)&gt; |\`-\`|
 |size|尺寸|[Size](#Size) |\`-\`|
@@ -1392,6 +1419,11 @@ export type TreeSelectDataType = TreeDataType & {
   getInnerMethods: (inner: boolean) => InnerMethodsReturnType;
 };
 \`\`\`",
+  "UnionBlinkProps": "### UnionBlinkProps
+
+\`\`\`js
+type UnionBlinkProps = ClinkProps & BlinkProps;
+\`\`\`",
   "onColumnCallbackProps": "### onColumnCallbackProps
 
 \`\`\`js
@@ -1418,6 +1450,7 @@ This is interface description.
 |treeSelectDataType|treeSelectDataType|[TreeSelectDataType](#TreeSelectDataType) |\`-\`|
 |onClick|onClick|(num: number) => void  **(Required)**|\`-\`|
 |b|BProps|[BlinkProps](blink#Blink)  **(Required)**|\`-\`|
+|unionBlink|baseBlink|[UnionBlinkProps](#UnionBlinkProps)  **(Required)**|\`-\`|
 |action|action|ReactNode |\`-\`|
 |owner|owner|Partial&lt;[Owner](#Owner)&gt; |\`-\`|
 |size|size|[Size](#Size) |\`-\`|
@@ -1504,6 +1537,11 @@ export type TreeDataType = {
 export type TreeSelectDataType = TreeDataType & {
   getInnerMethods: (inner: boolean) => InnerMethodsReturnType;
 };
+\`\`\`",
+  "UnionBlinkProps": "### UnionBlinkProps
+
+\`\`\`js
+type UnionBlinkProps = ClinkProps & BlinkProps;
 \`\`\`",
   "onColumnCallbackProps": "### onColumnCallbackProps
 

--- a/__test__/fixtures/nest/components/Blink/interface.ts
+++ b/__test__/fixtures/nest/components/Blink/interface.ts
@@ -16,7 +16,31 @@ export interface BlinkProps {
    * @en Whether to set flex layout properties
    */
   flex: boolean;
+  /**
+   * @zh 排序属性
+   * @en sorter
+   */
+  sorter: SorterProps;
   _privatePropThatShouldBeIgnored: ShouldBeIgnoredProps;
+}
+
+/**
+ * @title Clink
+ *
+ * @zh 这是 Clink 接口描述。
+ * @en This is interface description of Clink.
+ *
+ */
+export interface ClinkProps {
+  /**
+   * @zh 排序属性
+   * @en sorter
+   */
+  sorter: SorterProps;
+}
+
+interface SorterProps {
+  counter: number;
 }
 
 export interface ShouldBeIgnoredProps {

--- a/__test__/fixtures/nest/interface.ts
+++ b/__test__/fixtures/nest/interface.ts
@@ -1,5 +1,5 @@
 import { ReactNode, PropsWithChildren } from 'react';
-import { BlinkProps, ShouldBeIgnoredProps } from './components/Blink/interface';
+import { BlinkProps, ClinkProps, ShouldBeIgnoredProps } from './components/Blink/interface';
 
 export interface OptionInfo extends PropsWithChildren<BlinkProps> {
   valid: boolean;
@@ -30,6 +30,11 @@ export interface AProps {
    * @en BProps
    */
   b: BlinkProps;
+  /**
+   * @zh 属性 baseB
+   * @en baseBlink
+   */
+  unionBlink: UnionBlinkProps;
   /**
    * @zh 操作项
    * @en action
@@ -115,3 +120,5 @@ export type TreeDataType = {
 interface InnerMethodsReturnType {
   text: string;
 }
+
+type UnionBlinkProps = ClinkProps & BlinkProps;


### PR DESCRIPTION
What is done in the PR:

1. Escaping parsing types with JSDoc title. e.g

```ts
/**
 * @title Blink
 *
 * @zh 这是 Blink 接口描述。
 * @en This is interface description of Blink.
 *
 */
export interface BlinkProps {
  /**
   * @zh 数字
   * @en numbers
   */
  numbers: number[];
  /**
   * @zh 是否设置 flex 布局属性
   * @en Whether to set flex layout properties
   */
  flex: boolean;
  /**
   * @zh 排序属性
   * @en sorter
   */
  sorter: SorterProps;
  _privatePropThatShouldBeIgnored: ShouldBeIgnoredProps;
}
```
will NOT be parsed in nested types.


2. When linking displayed type text, use ast to target the type instead of regular expression 