### PR TITLE
feat: support escapeChars config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,13 @@ When parsing nested types, whether to ignore these nested types if they are defi
 When returning true, nested types must not be exported, but when false is returned,
 nested types may not be exported due to other reasons (such as the nested type has jsdoc @title, which needs to be manually exported)
 
-## Who's using?
+### escapeChars
+
+`boolean`: default to `true`
+
+Whether to escape characters for extracted type text. E.g. `|` will be escaped to `\|`, `<Promise>` will be escaped to `&lt;Promise&gt;`.
+
+## Who's using? 
 
 [Arco Design](https://github.com/arco-design/arco-design) - A comprehensive React UI components library based on Arco Design.
 

--- a/__test__/__snapshots__/index.test.ts.snap
+++ b/__test__/__snapshots__/index.test.ts.snap
@@ -128,6 +128,59 @@ Object {
 }
 `;
 
+exports[`generate escape 1`] = `
+Object {
+  "A": Object {
+    "data": Array [
+      Object {
+        "isOptional": true,
+        "name": "size",
+        "tags": Array [
+          Object {
+            "name": "zh",
+            "value": "尺寸",
+          },
+          Object {
+            "name": "en",
+            "value": "size",
+          },
+        ],
+        "type": "'mini' | 'large' | 'default'",
+      },
+      Object {
+        "isOptional": true,
+        "name": "fetchData",
+        "tags": Array [
+          Object {
+            "name": "zh",
+            "value": "获取数据函数",
+          },
+          Object {
+            "name": "en",
+            "value": "Function to fetch data",
+          },
+        ],
+        "type": "() => Promise<string>",
+      },
+    ],
+    "tags": Array [
+      Object {
+        "name": "title",
+        "value": "A",
+      },
+      Object {
+        "name": "zh",
+        "value": "这是接口描述。",
+      },
+      Object {
+        "name": "en",
+        "value": "This is interface description.",
+      },
+    ],
+  },
+}
+`;
+
 exports[`generate extends 1`] = `
 Object {
   "Alert": Object {
@@ -434,7 +487,7 @@ Object {
   },
   "ButtonType": Object {
     "data": "type ButtonType = {
-  size?: \\"mini\\" | \\"large\\" | \\"default\\";
+  size?: 'mini' | 'large' | 'default';
   color?: string;
 };
 ",
@@ -736,7 +789,7 @@ Object {
   LEFT,
   RIGHT,
   UP,
-  DOWN,
+  DOWN
 }
 ",
     "isNestedType": true,
@@ -764,7 +817,7 @@ Object {
     "data": "export interface OptionInfo extends PropsWithChildren<BlinkProps> {
   valid: boolean;
   index: number;
-  origin: \\"children\\" | \\"options\\" | \\"userCreatedOptions\\" | \\"userCreatingOption\\";
+  origin: 'children' | 'options' | 'userCreatedOptions' | 'userCreatingOption';
 }
 ",
     "isNestedType": true,
@@ -1087,7 +1140,7 @@ Object {
 
 \`\`\`js
 type ButtonType = {
-  size?: \\"mini\\" | \\"large\\" | \\"default\\";
+  size?: 'mini' | 'large' | 'default';
   color?: string;
 };
 \`\`\`",
@@ -1157,11 +1210,37 @@ Add two numbers
 
 \`\`\`js
 type ButtonType = {
-  size?: \\"mini\\" | \\"large\\" | \\"default\\";
+  size?: 'mini' | 'large' | 'default';
   color?: string;
 };
 \`\`\`",
 ]
+`;
+
+exports[`generateMarkdown escape 1`] = `
+Object {
+  "A": "### A
+
+这是接口描述。
+
+|参数名|描述|类型|默认值|
+|---|---|---|---|
+|size|尺寸|'mini' | 'large' | 'default' |\`-\`|
+|fetchData|获取数据函数|() => Promise<string> |\`-\`|",
+}
+`;
+
+exports[`generateMarkdown escape 2`] = `
+Object {
+  "A": "### A
+
+This is interface description.
+
+|Property|Description|Type|DefaultValue|
+|---|---|---|---|
+|size|size|'mini' | 'large' | 'default' |\`-\`|
+|fetchData|Function to fetch data|() => Promise<string> |\`-\`|",
+}
 `;
 
 exports[`generateMarkdown extends 1`] = `
@@ -1255,7 +1334,7 @@ Object {
 
 \`\`\`js
 type ButtonType = {
-  size?: \\"mini\\" | \\"large\\" | \\"default\\";
+  size?: 'mini' | 'large' | 'default';
   color?: string;
 };
 \`\`\`",
@@ -1325,7 +1404,7 @@ Add two numbers
 
 \`\`\`js
 type ButtonType = {
-  size?: \\"mini\\" | \\"large\\" | \\"default\\";
+  size?: 'mini' | 'large' | 'default';
   color?: string;
 };
 \`\`\`",
@@ -1368,7 +1447,7 @@ enum Direction {
   LEFT,
   RIGHT,
   UP,
-  DOWN,
+  DOWN
 }
 \`\`\`",
   "InnerMethodsReturnType": "### InnerMethodsReturnType
@@ -1384,7 +1463,7 @@ interface InnerMethodsReturnType {
 export interface OptionInfo extends PropsWithChildren<BlinkProps> {
   valid: boolean;
   index: number;
-  origin: \\"children\\" | \\"options\\" | \\"userCreatedOptions\\" | \\"userCreatingOption\\";
+  origin: 'children' | 'options' | 'userCreatedOptions' | 'userCreatingOption';
 }
 \`\`\`",
   "Owner": "### Owner
@@ -1487,7 +1566,7 @@ enum Direction {
   LEFT,
   RIGHT,
   UP,
-  DOWN,
+  DOWN
 }
 \`\`\`",
   "InnerMethodsReturnType": "### InnerMethodsReturnType
@@ -1503,7 +1582,7 @@ interface InnerMethodsReturnType {
 export interface OptionInfo extends PropsWithChildren<BlinkProps> {
   valid: boolean;
   index: number;
-  origin: \\"children\\" | \\"options\\" | \\"userCreatedOptions\\" | \\"userCreatingOption\\";
+  origin: 'children' | 'options' | 'userCreatedOptions' | 'userCreatingOption';
 }
 \`\`\`",
   "Owner": "### Owner

--- a/__test__/fixtures/escape.ts
+++ b/__test__/fixtures/escape.ts
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+/**
+ * @title A
+ *
+ * @zh 这是接口描述。
+ *
+ * @en This is interface description.
+ */
+export interface AProps {
+  /**
+   * @zh 尺寸
+   * @en size 
+   */
+  size?: 'mini' | 'large' | 'default';
+  /**
+   * @zh 获取数据函数
+   * @en Function to fetch data
+   */
+  fetchData?: () => Promise<string>;
+}
+
+

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -8,6 +8,7 @@ const pathDefaultMap = path.resolve(pathFixtures, 'defaultTypeMap.ts');
 const pathFunction = path.resolve(pathFixtures, 'function.ts');
 const pathPropertySorter = path.resolve(pathFixtures, 'propertySorter.ts');
 const pathNest = path.resolve(pathFixtures, 'nest/interface.ts');
+const pathEscape = path.resolve(pathFixtures, 'escape.ts');
 
 const nestLinkFormatter = (options) => {
   const { typeName, jsDocTitle, fullPath } = options;
@@ -79,6 +80,14 @@ describe('generate', () => {
     const schema = generate(pathNest, {
       sourceFilesPaths: './**/*.ts',
       linkFormatter: nestLinkFormatter,
+    });
+    expect(schema).toMatchSnapshot();
+  });
+
+  it('escape', () => {
+    const schema = generate(pathEscape, {
+      sourceFilesPaths: './**/*.ts',
+      escapeChars: false
     });
     expect(schema).toMatchSnapshot();
   });
@@ -156,6 +165,22 @@ describe('generateMarkdown', () => {
       sourceFilesPaths: './**/*.ts',
       lang: 'en',
       linkFormatter: nestLinkFormatter,
+    });
+    expect(markdownZh).toMatchSnapshot();
+    expect(markdownEn).toMatchSnapshot();
+  });
+
+  it('escape', () => {
+    const markdownZh = generateMarkdown(pathEscape, {
+      sourceFilesPaths: './**/*.ts',
+      lang: 'zh',
+      escapeChars: false
+      
+    });
+    const markdownEn = generateMarkdown(pathEscape, {
+      sourceFilesPaths: './**/*.ts',
+      lang: 'en',
+      escapeChars: false
     });
     expect(markdownZh).toMatchSnapshot();
     expect(markdownEn).toMatchSnapshot();

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -24,8 +24,7 @@ import {
   LinkFormatter,
 } from './interface';
 import { defaultTypeMap, defaultLinkFormatter } from './default';
-import { toSingleLine, escape } from './util';
-import { format } from 'prettier';
+import { toSingleLine } from './util';
 
 const dummyProject = new Project({ useInMemoryFileSystem: true });
 
@@ -174,7 +173,8 @@ function getDeclarationBySymbol(symbol?: Symbol) {
 
 function getDeclarationTextBySymbol(symbol?: Symbol) {
   const declaration = getDeclarationBySymbol(symbol);
-  return format(declaration?.print() || '', { parser: 'typescript' });
+  // Four spaces -> two spaces and add a new line at the end
+  return `${(declaration?.print() || '').replace(/ {4}/g, ' '.repeat(2))}\n`;
 }
 
 /**
@@ -253,7 +253,7 @@ function getDisplayTypeWithLink(
 ) {
   const sourceFile = dummyProject.createSourceFile(
     './dummy.ts',
-    toSingleLine(escape(originTypeText)),
+    toSingleLine(originTypeText, config.escapeChars),
     {
       overwrite: true,
     }
@@ -500,6 +500,7 @@ function generate(
     ignoreNestedType(definitionFilePath: string) {
       return definitionFilePath.includes('/node_modules/')
     },
+    escapeChars: true,
     ...config
   }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -81,6 +81,11 @@ export type GenerateConfig = {
    * When returning true, nested types must not be exported, but when false is returned, nested types may not be exported due to other reasons (such as the nested type has jsdoc @title, which needs to be manually exported)
    */
   ignoreNestedType?: (definitionFilePath: string) => boolean;
+  /*
+   * Whether to escape characters for extracted type text. 
+   * E.g. `|` will be escaped to `\|`, `<Promise>` will be escaped to `&lt;Promise&gt;`.
+   */
+   escapeChars?: boolean;
 };
 
 export type GenerateMarkdownConfig = GenerateConfig & {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,16 @@
-export function toSingleLine(str = ''): string {
+export function toSingleLine(str = '', escapeChars = true): string {
   if (!str) {
     return '';
   }
-  return str
-    .trim()
+  let newStr = str.trim()
     .replace(/[\r\n\t]+/g, '')
     .replace(/[\x20]{2,}/g, '')
-    .replace(/\|/g, '\\|');
+  if (escapeChars) {
+    newStr = escape(
+      newStr.replace(/\|/g, '\\|')
+    );
+  }
+  return newStr;
 }
 
 /**


### PR DESCRIPTION
改动: 

1. 支持 escapeChars 参数，默认为 `true` , 可配置是否对提取出来的类型文案进行 escape
2. 移除对 prettier 的强依赖，改用手写格式化方法格式化提取到的类型（e.g. 4空格 -> 2空格）